### PR TITLE
fix: adapt to the latest MoeFactory API response

### DIFF
--- a/nonebot_plugin_cnrail/__init__.py
+++ b/nonebot_plugin_cnrail/__init__.py
@@ -6,7 +6,7 @@ require("nonebot_plugin_htmlrender")
 from . import __main__ as __main__  # noqa: E402
 from .config import ConfigModel  # noqa: E402
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __plugin_meta__ = PluginMetadata(
     name="CNRail",
     description="查询 12306 列车时刻表",

--- a/nonebot_plugin_cnrail/data_source.py
+++ b/nonebot_plugin_cnrail/data_source.py
@@ -2,11 +2,13 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 import httpx
+from nonebot import logger
 from nonebot.compat import type_validate_python
 
 from .models import TrainDetailData, TrainSearchData, TrainSearchResult, TrainSNData
 
 MOERAIL_API_BASE = "https://rail.moefactory.com/api/"
+REQUEST_TIMEOUT = 15
 
 
 @dataclass
@@ -27,6 +29,7 @@ async def generate_word(train_code: str, train_date: str) -> str:
     async with httpx.AsyncClient(
         base_url=MOERAIL_API_BASE,
         follow_redirects=True,
+        timeout=REQUEST_TIMEOUT,
     ) as client:
         resp = await client.post(
             url="/trainNumber/query",
@@ -41,20 +44,28 @@ async def generate_word(train_code: str, train_date: str) -> str:
 
 
 async def get_train_sn(train_code: str) -> Optional[List[TrainSNData]]:
-    async with httpx.AsyncClient(
-        base_url=MOERAIL_API_BASE,
-        follow_redirects=True,
-    ) as client:
-        resp = await client.post(
-            url="/emuSerialNumber/query",
-            data={"keyword": train_code},
+    try:
+        async with httpx.AsyncClient(
+            base_url=MOERAIL_API_BASE,
+            follow_redirects=True,
+            timeout=REQUEST_TIMEOUT,
+        ) as client:
+            resp = await client.post(
+                url="/emuSerialNumber/query",
+                data={"keyword": train_code},
+            )
+            resp.raise_for_status()
+        payload = resp.json()
+        if payload.get("code") != 200:
+            raise ValueError(payload.get("message") or "unknown API error")
+        return (
+            type_validate_python(List[TrainSNData], payload["data"])
+            if payload.get("data")
+            else None
         )
-        resp.raise_for_status()
-    return (
-        type_validate_python(List[TrainSNData], resp.json()["data"])
-        if resp.json()["data"]
-        else None
-    )
+    except Exception:
+        logger.warning("Failed to query train serial number", exc_info=True)
+        return None
 
 
 async def query_train_info(
@@ -64,6 +75,7 @@ async def query_train_info(
     async with httpx.AsyncClient(
         base_url=MOERAIL_API_BASE,
         follow_redirects=True,
+        timeout=REQUEST_TIMEOUT,
     ) as client:
         resp = await client.post(
             url="/trainNumber/query",
@@ -83,6 +95,7 @@ async def query_train_info(
         async with httpx.AsyncClient(
             base_url=MOERAIL_API_BASE,
             follow_redirects=True,
+            timeout=REQUEST_TIMEOUT,
         ) as client:
             resp = await client.post(
                 url="/search/getTrainCandidates",
@@ -99,6 +112,7 @@ async def query_train_info(
     async with httpx.AsyncClient(
         base_url=MOERAIL_API_BASE,
         follow_redirects=True,
+        timeout=REQUEST_TIMEOUT,
     ) as client:
         resp = await client.post(
             url="/trainDetails/query",

--- a/nonebot_plugin_cnrail/models.py
+++ b/nonebot_plugin_cnrail/models.py
@@ -38,9 +38,9 @@ class TrainSearchData(CamelAliasModel):
 
 
 class TrainSearchResult(CamelAliasModel):
-    page_index: int
-    page_size: int
-    total_pages: int
+    cursor: int
+    count: int
+    has_more: bool
     total_count: int
     data: List[TrainSearchData]
 


### PR DESCRIPTION
## 问题

MoeFactory API 的列车查询响应结构已发生变化：

- 旧分页字段：`pageIndex`、`pageSize`、`totalPages`
- 当前分页字段：`cursor`、`count`、`hasMore`

现有模型校验因此失败，导致列车时刻表无法正常查询。

另外，车组号查询接口目前可能返回 HTTP 500。由于车组号属于可选信息，该接口失败不应导致整个时刻表查询失败。

## 修改

- 更新 `TrainSearchResult`，适配当前分页字段
- 为 API 请求设置 15 秒超时
- 将车组号查询改为可选流程，失败时记录日志并继续渲染时刻表

